### PR TITLE
feat: dual-confirmation security for terminatorban and discordbannerset

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.3.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.3.10/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: false

--- a/src/commands/discordbannerset.ts
+++ b/src/commands/discordbannerset.ts
@@ -1,0 +1,329 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  type ButtonInteraction,
+  ButtonStyle,
+  type ChatInputCommandInteraction,
+  EmbedBuilder,
+  type GuildMember,
+  GuildPremiumTier,
+  MessageFlags,
+  SlashCommandBuilder,
+} from "discord.js";
+import type { Command } from "../types/command";
+import { validateBannerImage } from "../utils/imageValidator";
+import { logBannerChange } from "../utils/logger";
+import {
+  createRequest,
+  getRequest,
+  removeRequest,
+  setMessageId,
+  TTL_MS,
+} from "../utils/pendingBanners";
+import { hasAuthorizedRole, isAdmin, isTerminator } from "../utils/roles";
+
+const DiscordBannerSetCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName("discordbannerset")
+    .setDescription(
+      "Set the server banner (requires second Terminator approval)",
+    )
+    .addAttachmentOption((option) =>
+      option
+        .setName("image")
+        .setDescription(
+          "Upload a banner image (PNG, JPG, GIF, WebP — max 10 MB)",
+        )
+        .setRequired(false),
+    )
+    .addStringOption((option) =>
+      option
+        .setName("url")
+        .setDescription("URL to a hosted banner image")
+        .setRequired(false),
+    ),
+
+  cooldown: 0,
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    const member = interaction.member as GuildMember;
+
+    if (!isAdmin(member) && !hasAuthorizedRole(member)) {
+      await interaction.reply({
+        content:
+          "❌ You do not have permission to use this command. Required roles: **Terminator**, **Marketer**, **Dev**.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const attachment = interaction.options.getAttachment("image");
+    const url = interaction.options.getString("url");
+
+    const validation = validateBannerImage(attachment, url);
+    if (!validation.valid) {
+      await interaction.reply({
+        content: `❌ ${validation.error}`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const { imageUrl, isAnimated } = validation;
+
+    const guild = interaction.guild!;
+    const requiredTier = isAnimated
+      ? GuildPremiumTier.Tier3
+      : GuildPremiumTier.Tier2;
+    const requiredLabel = isAnimated ? "Boost Level 3" : "Boost Level 2";
+
+    if (guild.premiumTier < requiredTier) {
+      await interaction.reply({
+        content: `❌ This server needs **${requiredLabel}** to set ${isAnimated ? "an animated " : "a "}banner. Current tier: **Level ${guild.premiumTier}**.`,
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (isAdmin(member)) {
+      await interaction.deferReply();
+
+      try {
+        await guild.setBanner(imageUrl!);
+
+        const successEmbed = new EmbedBuilder()
+          .setTitle("✅ Server Banner Updated")
+          .setDescription(
+            `Banner set by ${member} via **admin bypass** (no confirmation needed).`,
+          )
+          .setImage(imageUrl!)
+          .setColor(0x57f287)
+          .setTimestamp();
+
+        await interaction.editReply({ embeds: [successEmbed] });
+
+        await logBannerChange(interaction.client, {
+          guildId: guild.id,
+          submitterTag: member.user.tag,
+          submitterId: member.id,
+          imageUrl: imageUrl!,
+          adminBypass: true,
+        });
+      } catch (error) {
+        console.error("[BannerSet] Admin bypass failed:", error);
+        await interaction.editReply({
+          content: `❌ Failed to set the banner. Error: \`${(error as Error).message}\``,
+        });
+      }
+
+      return;
+    }
+
+    const voteChannelId = process.env.VOTE_CHANNEL_ID;
+    const voteChannel = voteChannelId
+      ? await interaction.client.channels.fetch(voteChannelId).catch(() => null)
+      : null;
+
+    if (
+      !voteChannel ||
+      !voteChannel.isTextBased() ||
+      !("send" in voteChannel)
+    ) {
+      await interaction.reply({
+        content:
+          "❌ Vote channel is not configured or not found. Please set `VOTE_CHANNEL_ID` in `.env`.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const requestId = createRequest({
+      submitterId: member.id,
+      submitterTag: member.user.tag,
+      imageUrl: imageUrl!,
+      guildId: guild.id,
+      channelId: voteChannelId!,
+    });
+
+    const expiresAt = Math.floor((Date.now() + TTL_MS) / 1000);
+
+    const confirmEmbed = new EmbedBuilder()
+      .setTitle("🖼️ Banner Change Request")
+      .setDescription(
+        `${member} wants to change the server banner.\n\n` +
+          `A **different Terminator** must approve this request.\n` +
+          `Expires: <t:${expiresAt}:R>`,
+      )
+      .setImage(imageUrl!)
+      .setColor(0xfee75c)
+      .addFields(
+        {
+          name: "Submitted By",
+          value: `${member} (${member.user.tag})`,
+          inline: true,
+        },
+        {
+          name: "Status",
+          value: "⏳ Awaiting confirmation",
+          inline: true,
+        },
+      )
+      .setFooter({ text: `Request ID: ${requestId}` })
+      .setTimestamp();
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`banner_approve_${requestId}`)
+        .setLabel("Approve")
+        .setStyle(ButtonStyle.Success)
+        .setEmoji("✅"),
+      new ButtonBuilder()
+        .setCustomId(`banner_reject_${requestId}`)
+        .setLabel("Reject")
+        .setStyle(ButtonStyle.Danger)
+        .setEmoji("❌"),
+    );
+
+    const voteMessage = await voteChannel.send({
+      embeds: [confirmEmbed],
+      components: [row],
+    });
+
+    setMessageId(requestId, voteMessage.id);
+
+    await interaction.reply({
+      content: `🖼️ Your banner change request has been submitted for approval in ${voteChannel}.`,
+      flags: MessageFlags.Ephemeral,
+    });
+  },
+
+  async handleButton(interaction: ButtonInteraction) {
+    const customId = interaction.customId;
+    const isApproval = customId.startsWith("banner_approve_");
+    const requestId = customId
+      .replace("banner_approve_", "")
+      .replace("banner_reject_", "");
+
+    const request = getRequest(requestId);
+
+    if (!request) {
+      await interaction.reply({
+        content:
+          "⏰ This banner request has **expired** or has already been processed.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const clicker = interaction.member as GuildMember;
+
+    if (!isTerminator(clicker)) {
+      await interaction.reply({
+        content:
+          "❌ Only members with the **Terminator** role can approve or reject banner requests.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!isApproval) {
+      removeRequest(requestId);
+
+      const rejectedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+        .setColor(0xed4245)
+        .setTitle("❌ Banner Change Rejected")
+        .spliceFields(1, 1, {
+          name: "Status",
+          value: `❌ Rejected by ${clicker}`,
+          inline: true,
+        });
+
+      const disabledRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`banner_approve_${requestId}`)
+          .setLabel("Approve")
+          .setStyle(ButtonStyle.Success)
+          .setEmoji("✅")
+          .setDisabled(true),
+        new ButtonBuilder()
+          .setCustomId(`banner_reject_${requestId}`)
+          .setLabel("Reject")
+          .setStyle(ButtonStyle.Danger)
+          .setEmoji("❌")
+          .setDisabled(true),
+      );
+
+      await interaction.update({
+        embeds: [rejectedEmbed],
+        components: [disabledRow],
+      });
+      return;
+    }
+
+    if (clicker.id === request.submitterId) {
+      await interaction.reply({
+        content:
+          "⚠️ You **cannot approve your own** banner submission. A **different** Terminator must approve it.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferUpdate();
+
+    try {
+      const guild = interaction.guild!;
+      await guild.setBanner(request.imageUrl);
+
+      removeRequest(requestId);
+
+      const approvedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+        .setColor(0x57f287)
+        .setTitle("✅ Banner Change Approved")
+        .spliceFields(1, 1, {
+          name: "Status",
+          value: `✅ Approved by ${clicker}`,
+          inline: true,
+        });
+
+      const disabledRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`banner_approve_${requestId}`)
+          .setLabel("Approve")
+          .setStyle(ButtonStyle.Success)
+          .setEmoji("✅")
+          .setDisabled(true),
+        new ButtonBuilder()
+          .setCustomId(`banner_reject_${requestId}`)
+          .setLabel("Reject")
+          .setStyle(ButtonStyle.Danger)
+          .setEmoji("❌")
+          .setDisabled(true),
+      );
+
+      await interaction.editReply({
+        embeds: [approvedEmbed],
+        components: [disabledRow],
+      });
+
+      await logBannerChange(interaction.client, {
+        guildId: guild.id,
+        submitterTag: request.submitterTag,
+        submitterId: request.submitterId,
+        approverTag: clicker.user.tag,
+        approverId: clicker.id,
+        imageUrl: request.imageUrl,
+        adminBypass: false,
+      });
+    } catch (error) {
+      console.error("[BannerSet] Approval failed:", error);
+      await interaction.editReply({
+        content: `❌ Failed to set the banner. Error: \`${(error as Error).message}\``,
+        embeds: [],
+        components: [],
+      });
+    }
+  },
+};
+
+export default DiscordBannerSetCommand;

--- a/src/commands/discordbannerset.ts
+++ b/src/commands/discordbannerset.ts
@@ -71,7 +71,8 @@ const DiscordBannerSetCommand: Command = {
 
     const { imageUrl, isAnimated } = validation;
 
-    const guild = interaction.guild!;
+    const guild = interaction.guild;
+    if (!guild) return;
     const requiredTier = isAnimated
       ? GuildPremiumTier.Tier3
       : GuildPremiumTier.Tier2;
@@ -86,17 +87,17 @@ const DiscordBannerSetCommand: Command = {
     }
 
     if (isAdmin(member)) {
-      await interaction.deferReply();
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       try {
-        await guild.setBanner(imageUrl!);
+        await guild.setBanner(imageUrl as string);
 
         const successEmbed = new EmbedBuilder()
           .setTitle("✅ Server Banner Updated")
           .setDescription(
             `Banner set by ${member} via **admin bypass** (no confirmation needed).`,
           )
-          .setImage(imageUrl!)
+          .setImage(imageUrl as string)
           .setColor(0x57f287)
           .setTimestamp();
 
@@ -106,7 +107,7 @@ const DiscordBannerSetCommand: Command = {
           guildId: guild.id,
           submitterTag: member.user.tag,
           submitterId: member.id,
-          imageUrl: imageUrl!,
+          imageUrl: imageUrl as string,
           adminBypass: true,
         });
       } catch (error) {
@@ -140,9 +141,9 @@ const DiscordBannerSetCommand: Command = {
     const requestId = createRequest({
       submitterId: member.id,
       submitterTag: member.user.tag,
-      imageUrl: imageUrl!,
+      imageUrl: imageUrl as string,
       guildId: guild.id,
-      channelId: voteChannelId!,
+      channelId: voteChannelId as string,
     });
 
     const expiresAt = Math.floor((Date.now() + TTL_MS) / 1000);
@@ -154,7 +155,7 @@ const DiscordBannerSetCommand: Command = {
           `A **different Terminator** must approve this request.\n` +
           `Expires: <t:${expiresAt}:R>`,
       )
-      .setImage(imageUrl!)
+      .setImage(imageUrl as string)
       .setColor(0xfee75c)
       .addFields(
         {
@@ -229,14 +230,30 @@ const DiscordBannerSetCommand: Command = {
     if (!isApproval) {
       removeRequest(requestId);
 
-      const rejectedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+      const originalEmbed = interaction.message.embeds[0];
+      if (!originalEmbed) {
+        await interaction.reply({
+          content:
+            "❌ Could not process this request — the original embed is missing.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      const embedFields = originalEmbed.fields;
+      const statusIndex = embedFields.findIndex((f) => f.name === "Status");
+
+      const rejectedEmbed = EmbedBuilder.from(originalEmbed)
         .setColor(0xed4245)
-        .setTitle("❌ Banner Change Rejected")
-        .spliceFields(1, 1, {
+        .setTitle("❌ Banner Change Rejected");
+
+      if (statusIndex !== -1) {
+        rejectedEmbed.spliceFields(statusIndex, 1, {
           name: "Status",
           value: `❌ Rejected by ${clicker}`,
           inline: true,
         });
+      }
 
       const disabledRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder()
@@ -269,22 +286,39 @@ const DiscordBannerSetCommand: Command = {
       return;
     }
 
+    const originalEmbed = interaction.message.embeds[0];
+    if (!originalEmbed) {
+      await interaction.reply({
+        content:
+          "❌ Could not process this request — the original embed is missing.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
     await interaction.deferUpdate();
 
     try {
-      const guild = interaction.guild!;
+      const guild = interaction.guild;
+      if (!guild) return;
       await guild.setBanner(request.imageUrl);
 
       removeRequest(requestId);
 
-      const approvedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+      const embedFields = originalEmbed.fields;
+      const statusIndex = embedFields.findIndex((f) => f.name === "Status");
+
+      const approvedEmbed = EmbedBuilder.from(originalEmbed)
         .setColor(0x57f287)
-        .setTitle("✅ Banner Change Approved")
-        .spliceFields(1, 1, {
+        .setTitle("✅ Banner Change Approved");
+
+      if (statusIndex !== -1) {
+        approvedEmbed.spliceFields(statusIndex, 1, {
           name: "Status",
           value: `✅ Approved by ${clicker}`,
           inline: true,
         });
+      }
 
       const disabledRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
         new ButtonBuilder()

--- a/src/commands/discordbannerset.ts
+++ b/src/commands/discordbannerset.ts
@@ -20,7 +20,11 @@ import {
   setMessageId,
   TTL_MS,
 } from "../utils/pendingBanners";
-import { hasAuthorizedRole, isAdmin, isTerminator } from "../utils/roles";
+import {
+  hasAdministratorPermission,
+  hasAuthorizedRole,
+  isTerminator,
+} from "../utils/roles";
 
 const DiscordBannerSetCommand: Command = {
   data: new SlashCommandBuilder()
@@ -48,7 +52,7 @@ const DiscordBannerSetCommand: Command = {
   async execute(interaction: ChatInputCommandInteraction) {
     const member = interaction.member as GuildMember;
 
-    if (!isAdmin(member) && !hasAuthorizedRole(member)) {
+    if (!hasAdministratorPermission(member) && !hasAuthorizedRole(member)) {
       await interaction.reply({
         content:
           "❌ You do not have permission to use this command. Required roles: **Terminator**, **Marketer**, **Dev**.",
@@ -86,7 +90,7 @@ const DiscordBannerSetCommand: Command = {
       return;
     }
 
-    if (isAdmin(member)) {
+    if (hasAdministratorPermission(member)) {
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       try {

--- a/src/commands/terminatorban.ts
+++ b/src/commands/terminatorban.ts
@@ -1,0 +1,417 @@
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  type ButtonInteraction,
+  ButtonStyle,
+  type ChatInputCommandInteraction,
+  EmbedBuilder,
+  type GuildMember,
+  MessageFlags,
+  SlashCommandBuilder,
+} from "discord.js";
+import type { Command } from "../types/command";
+import { logBanAction } from "../utils/logger";
+import {
+  BAN_TTL_MS,
+  createBanRequest,
+  getBanRequest,
+  removeBanRequest,
+  setBanMessageId,
+} from "../utils/pendingBans";
+import { hasAuthorizedRole, isAdmin, isTerminator } from "../utils/roles";
+
+const TerminatorBanCommand: Command = {
+  data: new SlashCommandBuilder()
+    .setName("terminatorban")
+    .setDescription("Ban a user (requires second Terminator approval)")
+    .addUserOption((option) =>
+      option
+        .setName("user")
+        .setDescription("The user to ban")
+        .setRequired(true),
+    )
+    .addStringOption((option) =>
+      option
+        .setName("reason")
+        .setDescription("Reason for the ban")
+        .setRequired(false),
+    )
+    .addIntegerOption((option) =>
+      option
+        .setName("delete_messages")
+        .setDescription("Days of messages to delete (0-7)")
+        .setRequired(false)
+        .setMinValue(0)
+        .setMaxValue(7),
+    ),
+
+  cooldown: 0,
+
+  async execute(interaction: ChatInputCommandInteraction) {
+    const member = interaction.member as GuildMember;
+
+    if (!isAdmin(member) && !hasAuthorizedRole(member)) {
+      await interaction.reply({
+        content:
+          "❌ You do not have permission to use this command. Required roles: **Terminator**, **Marketer**, **Dev**.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const targetUser = interaction.options.getUser("user", true);
+    const reason =
+      interaction.options.getString("reason") ?? "No reason provided";
+    const deleteMessageDays =
+      interaction.options.getInteger("delete_messages") ?? 0;
+
+    const guild = interaction.guild!;
+
+    if (targetUser.id === member.id) {
+      await interaction.reply({
+        content: "❌ You cannot ban yourself.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (targetUser.id === interaction.client.user?.id) {
+      await interaction.reply({
+        content: "❌ I cannot ban myself.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    let targetMember: GuildMember | null = null;
+    try {
+      targetMember = await guild.members.fetch(targetUser.id);
+    } catch {}
+
+    if (targetMember) {
+      if (
+        targetMember.roles.highest.position >= member.roles.highest.position &&
+        !isAdmin(member)
+      ) {
+        await interaction.reply({
+          content:
+            "❌ You cannot ban someone with a **higher or equal** role than yours.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      const botMember = guild.members.me!;
+      if (
+        targetMember.roles.highest.position >= botMember.roles.highest.position
+      ) {
+        await interaction.reply({
+          content:
+            "❌ I cannot ban this user — their role is **higher or equal** to mine.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      if (!targetMember.bannable) {
+        await interaction.reply({
+          content:
+            "❌ I cannot ban this user. They may be the server owner or have special protections.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+    }
+
+    if (isAdmin(member)) {
+      await interaction.deferReply();
+
+      try {
+        await guild.members.ban(targetUser.id, {
+          deleteMessageSeconds: deleteMessageDays * 86400,
+          reason: `Banned by ${member.user.tag} (admin bypass) — ${reason}`,
+        });
+
+        const successEmbed = new EmbedBuilder()
+          .setTitle("🔨 User Banned")
+          .setDescription(
+            `${targetUser} has been banned by ${member} via **admin bypass**.\n` +
+              "No second confirmation was needed.",
+          )
+          .setColor(0xed4245)
+          .addFields(
+            {
+              name: "Banned User",
+              value: `${targetUser.tag} (${targetUser.id})`,
+              inline: true,
+            },
+            { name: "Reason", value: reason, inline: true },
+            {
+              name: "Messages Deleted",
+              value: `${deleteMessageDays} day(s)`,
+              inline: true,
+            },
+          )
+          .setThumbnail(targetUser.displayAvatarURL())
+          .setTimestamp();
+
+        await interaction.editReply({ embeds: [successEmbed] });
+
+        await logBanAction(interaction.client, {
+          guildId: guild.id,
+          submitterTag: member.user.tag,
+          submitterId: member.id,
+          targetTag: targetUser.tag,
+          targetId: targetUser.id,
+          reason,
+          adminBypass: true,
+        });
+      } catch (error) {
+        console.error("[TerminatorBan] Admin bypass failed:", error);
+        await interaction.editReply({
+          content: `❌ Failed to ban user. Error: \`${(error as Error).message}\``,
+        });
+      }
+
+      return;
+    }
+
+    const voteChannelId = process.env.VOTE_CHANNEL_ID;
+    const voteChannel = voteChannelId
+      ? await interaction.client.channels.fetch(voteChannelId).catch(() => null)
+      : null;
+
+    if (
+      !voteChannel ||
+      !voteChannel.isTextBased() ||
+      !("send" in voteChannel)
+    ) {
+      await interaction.reply({
+        content:
+          "❌ Vote channel is not configured or not found. Please set `VOTE_CHANNEL_ID` in `.env`.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const requestId = createBanRequest({
+      submitterId: member.id,
+      submitterTag: member.user.tag,
+      targetId: targetUser.id,
+      targetTag: targetUser.tag,
+      reason,
+      deleteMessageDays,
+      guildId: guild.id,
+      channelId: voteChannelId!,
+    });
+
+    const expiresAt = Math.floor((Date.now() + BAN_TTL_MS) / 1000);
+
+    const confirmEmbed = new EmbedBuilder()
+      .setTitle("🔨 Ban Request")
+      .setDescription(
+        `${member} wants to ban ${targetUser}.\n\n` +
+          `A **different Terminator** must approve this request.\n` +
+          `Expires: <t:${expiresAt}:R>`,
+      )
+      .setColor(0xfee75c)
+      .addFields(
+        {
+          name: "Target",
+          value: `${targetUser.tag} (${targetUser.id})`,
+          inline: true,
+        },
+        {
+          name: "Requested By",
+          value: `${member} (${member.user.tag})`,
+          inline: true,
+        },
+        { name: "Reason", value: reason, inline: false },
+        {
+          name: "Messages to Delete",
+          value: `${deleteMessageDays} day(s)`,
+          inline: true,
+        },
+        {
+          name: "Status",
+          value: "⏳ Awaiting confirmation",
+          inline: true,
+        },
+      )
+      .setThumbnail(targetUser.displayAvatarURL())
+      .setFooter({ text: `Request ID: ${requestId}` })
+      .setTimestamp();
+
+    const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+      new ButtonBuilder()
+        .setCustomId(`ban_approve_${requestId}`)
+        .setLabel("Approve Ban")
+        .setStyle(ButtonStyle.Danger)
+        .setEmoji("🔨"),
+      new ButtonBuilder()
+        .setCustomId(`ban_reject_${requestId}`)
+        .setLabel("Reject")
+        .setStyle(ButtonStyle.Secondary)
+        .setEmoji("❌"),
+    );
+
+    const voteMessage = await voteChannel.send({
+      embeds: [confirmEmbed],
+      components: [row],
+    });
+
+    setBanMessageId(requestId, voteMessage.id);
+
+    await interaction.reply({
+      content: `🔨 Your ban request for **${targetUser.tag}** has been submitted for approval in ${voteChannel}.`,
+      flags: MessageFlags.Ephemeral,
+    });
+  },
+
+  async handleButton(interaction: ButtonInteraction) {
+    const customId = interaction.customId;
+    const isApproval = customId.startsWith("ban_approve_");
+    const requestId = customId
+      .replace("ban_approve_", "")
+      .replace("ban_reject_", "");
+
+    const request = getBanRequest(requestId);
+
+    if (!request) {
+      await interaction.reply({
+        content:
+          "⏰ This ban request has **expired** or has already been processed.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    const clicker = interaction.member as GuildMember;
+
+    if (!isTerminator(clicker)) {
+      await interaction.reply({
+        content:
+          "❌ Only members with the **Terminator** role can approve or reject ban requests.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    if (!isApproval) {
+      removeBanRequest(requestId);
+
+      const embedFields = interaction.message.embeds[0].fields;
+      const statusIndex = embedFields.findIndex((f) => f.name === "Status");
+
+      const rejectedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+        .setColor(0x95a5a6)
+        .setTitle("❌ Ban Request Rejected");
+
+      if (statusIndex !== -1) {
+        rejectedEmbed.spliceFields(statusIndex, 1, {
+          name: "Status",
+          value: `❌ Rejected by ${clicker}`,
+          inline: true,
+        });
+      }
+
+      const disabledRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`ban_approve_${requestId}`)
+          .setLabel("Approve Ban")
+          .setStyle(ButtonStyle.Danger)
+          .setEmoji("🔨")
+          .setDisabled(true),
+        new ButtonBuilder()
+          .setCustomId(`ban_reject_${requestId}`)
+          .setLabel("Reject")
+          .setStyle(ButtonStyle.Secondary)
+          .setEmoji("❌")
+          .setDisabled(true),
+      );
+
+      await interaction.update({
+        embeds: [rejectedEmbed],
+        components: [disabledRow],
+      });
+      return;
+    }
+
+    if (clicker.id === request.submitterId) {
+      await interaction.reply({
+        content:
+          "⚠️ You **cannot approve your own** ban request. A **different** Terminator must approve it.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
+    await interaction.deferUpdate();
+
+    try {
+      const guild = interaction.guild!;
+      await guild.members.ban(request.targetId, {
+        deleteMessageSeconds: request.deleteMessageDays * 86400,
+        reason: `Banned by ${request.submitterTag}, approved by ${clicker.user.tag} — ${request.reason}`,
+      });
+
+      removeBanRequest(requestId);
+
+      const embedFields = interaction.message.embeds[0].fields;
+      const statusIndex = embedFields.findIndex((f) => f.name === "Status");
+
+      const approvedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+        .setColor(0xed4245)
+        .setTitle("🔨 Ban Approved & Executed");
+
+      if (statusIndex !== -1) {
+        approvedEmbed.spliceFields(statusIndex, 1, {
+          name: "Status",
+          value: `✅ Approved by ${clicker}`,
+          inline: true,
+        });
+      }
+
+      const disabledRow = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setCustomId(`ban_approve_${requestId}`)
+          .setLabel("Approve Ban")
+          .setStyle(ButtonStyle.Danger)
+          .setEmoji("🔨")
+          .setDisabled(true),
+        new ButtonBuilder()
+          .setCustomId(`ban_reject_${requestId}`)
+          .setLabel("Reject")
+          .setStyle(ButtonStyle.Secondary)
+          .setEmoji("❌")
+          .setDisabled(true),
+      );
+
+      await interaction.editReply({
+        embeds: [approvedEmbed],
+        components: [disabledRow],
+      });
+
+      await logBanAction(interaction.client, {
+        guildId: guild.id,
+        submitterTag: request.submitterTag,
+        submitterId: request.submitterId,
+        approverTag: clicker.user.tag,
+        approverId: clicker.id,
+        targetTag: request.targetTag,
+        targetId: request.targetId,
+        reason: request.reason,
+        adminBypass: false,
+      });
+    } catch (error) {
+      console.error("[TerminatorBan] Approval failed:", error);
+      await interaction.editReply({
+        content: `❌ Failed to ban user. Error: \`${(error as Error).message}\``,
+        embeds: [],
+        components: [],
+      });
+    }
+  },
+};
+
+export default TerminatorBanCommand;

--- a/src/commands/terminatorban.ts
+++ b/src/commands/terminatorban.ts
@@ -65,7 +65,8 @@ const TerminatorBanCommand: Command = {
     const deleteMessageDays =
       interaction.options.getInteger("delete_messages") ?? 0;
 
-    const guild = interaction.guild!;
+    const guild = interaction.guild;
+    if (!guild) return;
 
     if (targetUser.id === member.id) {
       await interaction.reply({
@@ -101,7 +102,8 @@ const TerminatorBanCommand: Command = {
         return;
       }
 
-      const botMember = guild.members.me!;
+      const botMember = guild.members.me;
+      if (!botMember) return;
       if (
         targetMember.roles.highest.position >= botMember.roles.highest.position
       ) {
@@ -124,7 +126,7 @@ const TerminatorBanCommand: Command = {
     }
 
     if (isAdmin(member)) {
-      await interaction.deferReply();
+      await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       try {
         await guild.members.ban(targetUser.id, {
@@ -202,7 +204,7 @@ const TerminatorBanCommand: Command = {
       reason,
       deleteMessageDays,
       guildId: guild.id,
-      channelId: voteChannelId!,
+      channelId: voteChannelId as string,
     });
 
     const expiresAt = Math.floor((Date.now() + BAN_TTL_MS) / 1000);
@@ -300,10 +302,20 @@ const TerminatorBanCommand: Command = {
     if (!isApproval) {
       removeBanRequest(requestId);
 
-      const embedFields = interaction.message.embeds[0].fields;
+      const originalEmbed = interaction.message.embeds[0];
+      if (!originalEmbed) {
+        await interaction.reply({
+          content:
+            "❌ Could not process this request — the original embed is missing.",
+          flags: MessageFlags.Ephemeral,
+        });
+        return;
+      }
+
+      const embedFields = originalEmbed.fields;
       const statusIndex = embedFields.findIndex((f) => f.name === "Status");
 
-      const rejectedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+      const rejectedEmbed = EmbedBuilder.from(originalEmbed)
         .setColor(0x95a5a6)
         .setTitle("❌ Ban Request Rejected");
 
@@ -346,10 +358,21 @@ const TerminatorBanCommand: Command = {
       return;
     }
 
+    const originalEmbed = interaction.message.embeds[0];
+    if (!originalEmbed) {
+      await interaction.reply({
+        content:
+          "❌ Could not process this request — the original embed is missing.",
+        flags: MessageFlags.Ephemeral,
+      });
+      return;
+    }
+
     await interaction.deferUpdate();
 
     try {
-      const guild = interaction.guild!;
+      const guild = interaction.guild;
+      if (!guild) return;
       await guild.members.ban(request.targetId, {
         deleteMessageSeconds: request.deleteMessageDays * 86400,
         reason: `Banned by ${request.submitterTag}, approved by ${clicker.user.tag} — ${request.reason}`,
@@ -357,10 +380,10 @@ const TerminatorBanCommand: Command = {
 
       removeBanRequest(requestId);
 
-      const embedFields = interaction.message.embeds[0].fields;
+      const embedFields = originalEmbed.fields;
       const statusIndex = embedFields.findIndex((f) => f.name === "Status");
 
-      const approvedEmbed = EmbedBuilder.from(interaction.message.embeds[0])
+      const approvedEmbed = EmbedBuilder.from(originalEmbed)
         .setColor(0xed4245)
         .setTitle("🔨 Ban Approved & Executed");
 

--- a/src/commands/terminatorban.ts
+++ b/src/commands/terminatorban.ts
@@ -18,7 +18,11 @@ import {
   removeBanRequest,
   setBanMessageId,
 } from "../utils/pendingBans";
-import { hasAuthorizedRole, isAdmin, isTerminator } from "../utils/roles";
+import {
+  hasAdministratorPermission,
+  hasAuthorizedRole,
+  isTerminator,
+} from "../utils/roles";
 
 const TerminatorBanCommand: Command = {
   data: new SlashCommandBuilder()
@@ -50,7 +54,7 @@ const TerminatorBanCommand: Command = {
   async execute(interaction: ChatInputCommandInteraction) {
     const member = interaction.member as GuildMember;
 
-    if (!isAdmin(member) && !hasAuthorizedRole(member)) {
+    if (!hasAdministratorPermission(member) && !hasAuthorizedRole(member)) {
       await interaction.reply({
         content:
           "❌ You do not have permission to use this command. Required roles: **Terminator**, **Marketer**, **Dev**.",
@@ -92,7 +96,7 @@ const TerminatorBanCommand: Command = {
     if (targetMember) {
       if (
         targetMember.roles.highest.position >= member.roles.highest.position &&
-        !isAdmin(member)
+        !hasAdministratorPermission(member)
       ) {
         await interaction.reply({
           content:
@@ -125,7 +129,7 @@ const TerminatorBanCommand: Command = {
       }
     }
 
-    if (isAdmin(member)) {
+    if (hasAdministratorPermission(member)) {
       await interaction.deferReply({ flags: MessageFlags.Ephemeral });
 
       try {

--- a/src/events/interactionCreate.ts
+++ b/src/events/interactionCreate.ts
@@ -1,4 +1,8 @@
-import { type Interaction, PermissionsBitField } from "discord.js";
+import {
+  type Interaction,
+  MessageFlags,
+  PermissionsBitField,
+} from "discord.js";
 import config from "../config/config";
 import type { CommandManager } from "../utils/commandManager";
 
@@ -121,10 +125,55 @@ async function handleRoleMenu(interaction: Interaction) {
   }
 }
 
+async function handleButtonInteraction(
+  commandManager: CommandManager,
+  interaction: Interaction,
+) {
+  if (!interaction.isButton()) return;
+
+  const customId = interaction.customId;
+  let commandName: string | null = null;
+
+  if (
+    customId.startsWith("banner_approve_") ||
+    customId.startsWith("banner_reject_")
+  ) {
+    commandName = "discordbannerset";
+  } else if (
+    customId.startsWith("ban_approve_") ||
+    customId.startsWith("ban_reject_")
+  ) {
+    commandName = "terminatorban";
+  }
+
+  if (!commandName) return;
+
+  const command = commandManager.getCommands().get(commandName);
+  if (!command?.handleButton) return;
+
+  try {
+    await command.handleButton(interaction);
+  } catch (error) {
+    console.error(`[Button Error] ${commandName}:`, error);
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp({
+        content: "❌ An error occurred while processing this action.",
+        flags: MessageFlags.Ephemeral,
+      });
+    } else {
+      await interaction.reply({
+        content: "❌ An error occurred while processing this action.",
+        flags: MessageFlags.Ephemeral,
+      });
+    }
+  }
+}
+
 export const onInteractionCreate = async (
   commandManager: CommandManager,
   interaction: Interaction,
 ) => {
   await handleCommand(commandManager, interaction);
   await handleRoleMenu(interaction);
+  await handleButtonInteraction(commandManager, interaction);
 };

--- a/src/utils/imageValidator.ts
+++ b/src/utils/imageValidator.ts
@@ -1,0 +1,96 @@
+import type { Attachment } from "discord.js";
+
+export const ALLOWED_CONTENT_TYPES = [
+  "image/png",
+  "image/jpeg",
+  "image/jpg",
+  "image/gif",
+  "image/webp",
+] as const;
+
+export const MAX_FILE_SIZE = 10 * 1024 * 1024; // 10 MB
+
+export interface ValidationResult {
+  valid: boolean;
+  imageUrl?: string;
+  error?: string;
+  isAnimated?: boolean;
+}
+
+export function validateBannerImage(
+  attachment: Attachment | null,
+  url: string | null,
+): ValidationResult {
+  if (!attachment && !url) {
+    return {
+      valid: false,
+      error:
+        "You must provide either an **image attachment** or an **image URL**.",
+    };
+  }
+
+  if (attachment) {
+    const contentType = attachment.contentType?.split(";")[0];
+    if (
+      contentType &&
+      !(ALLOWED_CONTENT_TYPES as readonly string[]).includes(contentType)
+    ) {
+      return {
+        valid: false,
+        error: `Invalid file type: \`${attachment.contentType}\`. Allowed types: PNG, JPG, GIF, WebP.`,
+      };
+    }
+
+    if (attachment.size > MAX_FILE_SIZE) {
+      const sizeMB = (attachment.size / (1024 * 1024)).toFixed(1);
+      return {
+        valid: false,
+        error: `File too large: \`${sizeMB} MB\`. Maximum allowed size is **10 MB**.`,
+      };
+    }
+
+    const isAnimated =
+      attachment.contentType?.includes("gif") ||
+      attachment.name?.endsWith(".gif") ||
+      false;
+
+    return { valid: true, imageUrl: attachment.url, isAnimated };
+  }
+
+  if (url) {
+    try {
+      const parsed = new URL(url);
+      if (!["http:", "https:"].includes(parsed.protocol)) {
+        return {
+          valid: false,
+          error: "URL must use `http://` or `https://` protocol.",
+        };
+      }
+    } catch {
+      return {
+        valid: false,
+        error: "Invalid URL format. Please provide a valid image URL.",
+      };
+    }
+
+    const lowerUrl = url.toLowerCase().split("?")[0];
+    const validExtensions = [".png", ".jpg", ".jpeg", ".gif", ".webp"];
+    const hasValidExtension = validExtensions.some((ext) =>
+      lowerUrl.endsWith(ext),
+    );
+
+    if (!hasValidExtension) {
+      return {
+        valid: false,
+        error:
+          "URL does not appear to point to a valid image. Supported formats: PNG, JPG, GIF, WebP.",
+      };
+    }
+
+    const isAnimated = lowerUrl.endsWith(".gif");
+
+    return { valid: true, imageUrl: url, isAnimated };
+  }
+
+  return { valid: false, error: "Unexpected error validating image." };
+}

--- a/src/utils/imageValidator.ts
+++ b/src/utils/imageValidator.ts
@@ -31,14 +31,24 @@ export function validateBannerImage(
 
   if (attachment) {
     const contentType = attachment.contentType?.split(";")[0];
-    if (
-      contentType &&
-      !(ALLOWED_CONTENT_TYPES as readonly string[]).includes(contentType)
-    ) {
-      return {
-        valid: false,
-        error: `Invalid file type: \`${attachment.contentType}\`. Allowed types: PNG, JPG, GIF, WebP.`,
-      };
+    if (contentType) {
+      if (!(ALLOWED_CONTENT_TYPES as readonly string[]).includes(contentType)) {
+        return {
+          valid: false,
+          error: `Invalid file type: \`${attachment.contentType}\`. Allowed types: PNG, JPG, GIF, WebP.`,
+        };
+      }
+    } else {
+      // contentType is missing — fall back to file extension check
+      const validExtensions = [".png", ".jpg", ".jpeg", ".gif", ".webp"];
+      const fileName = attachment.name?.toLowerCase() ?? "";
+      if (!validExtensions.some((ext) => fileName.endsWith(ext))) {
+        return {
+          valid: false,
+          error:
+            "Could not determine file type. Please upload a PNG, JPG, GIF, or WebP image.",
+        };
+      }
     }
 
     if (attachment.size > MAX_FILE_SIZE) {

--- a/src/utils/imageValidator.ts
+++ b/src/utils/imageValidator.ts
@@ -60,8 +60,8 @@ export function validateBannerImage(
     }
 
     const isAnimated =
-      attachment.contentType?.includes("gif") ||
-      attachment.name?.endsWith(".gif") ||
+      attachment.contentType?.toLowerCase().includes("gif") ||
+      attachment.name?.toLowerCase().endsWith(".gif") ||
       false;
 
     return { valid: true, imageUrl: attachment.url, isAnimated };

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,0 +1,140 @@
+import { type Client, EmbedBuilder } from "discord.js";
+
+export interface BannerChangeLogOptions {
+  guildId: string;
+  submitterTag: string;
+  submitterId: string;
+  approverTag?: string;
+  approverId?: string;
+  imageUrl: string;
+  adminBypass: boolean;
+}
+
+export async function logBannerChange(
+  client: Client,
+  opts: BannerChangeLogOptions,
+): Promise<void> {
+  const logChannelId = process.env.LOG_CHANNEL_ID;
+  if (!logChannelId) {
+    console.warn(
+      "[Logger] LOG_CHANNEL_ID not set in .env — skipping audit log.",
+    );
+    return;
+  }
+
+  try {
+    const channel = await client.channels.fetch(logChannelId);
+    if (!channel || !channel.isTextBased() || !("send" in channel)) {
+      console.warn(
+        `[Logger] Channel ${logChannelId} not found or not text-based.`,
+      );
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle("🖼️ Server Banner Changed")
+      .setColor(0x2b2d31)
+      .setImage(opts.imageUrl)
+      .setTimestamp()
+      .addFields({
+        name: "Submitted By",
+        value: `<@${opts.submitterId}> (${opts.submitterTag})`,
+        inline: true,
+      });
+
+    if (opts.adminBypass) {
+      embed.addFields({
+        name: "Approved Via",
+        value: "🛡️ Admin Bypass",
+        inline: true,
+      });
+    } else if (opts.approverTag && opts.approverId) {
+      embed.addFields({
+        name: "Approved By",
+        value: `<@${opts.approverId}> (${opts.approverTag})`,
+        inline: true,
+      });
+    }
+
+    embed.addFields({
+      name: "Image URL",
+      value: `[Click to view](${opts.imageUrl})`,
+      inline: false,
+    });
+
+    await channel.send({ embeds: [embed] });
+  } catch (error) {
+    console.error("[Logger] Failed to send audit log:", error);
+  }
+}
+
+export interface BanActionLogOptions {
+  guildId: string;
+  submitterTag: string;
+  submitterId: string;
+  approverTag?: string;
+  approverId?: string;
+  targetTag: string;
+  targetId: string;
+  reason: string;
+  adminBypass: boolean;
+}
+
+export async function logBanAction(
+  client: Client,
+  opts: BanActionLogOptions,
+): Promise<void> {
+  const logChannelId = process.env.LOG_CHANNEL_ID;
+  if (!logChannelId) {
+    console.warn(
+      "[Logger] LOG_CHANNEL_ID not set in .env — skipping audit log.",
+    );
+    return;
+  }
+
+  try {
+    const channel = await client.channels.fetch(logChannelId);
+    if (!channel || !channel.isTextBased() || !("send" in channel)) {
+      console.warn(
+        `[Logger] Channel ${logChannelId} not found or not text-based.`,
+      );
+      return;
+    }
+
+    const embed = new EmbedBuilder()
+      .setTitle("🔨 User Banned")
+      .setColor(0xed4245)
+      .setTimestamp()
+      .addFields(
+        {
+          name: "Banned User",
+          value: `<@${opts.targetId}> (${opts.targetTag})`,
+          inline: true,
+        },
+        {
+          name: "Banned By",
+          value: `<@${opts.submitterId}> (${opts.submitterTag})`,
+          inline: true,
+        },
+        { name: "Reason", value: opts.reason, inline: false },
+      );
+
+    if (opts.adminBypass) {
+      embed.addFields({
+        name: "Approved Via",
+        value: "🛡️ Admin Bypass",
+        inline: true,
+      });
+    } else if (opts.approverTag && opts.approverId) {
+      embed.addFields({
+        name: "Approved By",
+        value: `<@${opts.approverId}> (${opts.approverTag})`,
+        inline: true,
+      });
+    }
+
+    await channel.send({ embeds: [embed] });
+  } catch (error) {
+    console.error("[Logger] Failed to send ban audit log:", error);
+  }
+}

--- a/src/utils/pendingBanners.ts
+++ b/src/utils/pendingBanners.ts
@@ -1,0 +1,68 @@
+import { randomUUID } from "node:crypto";
+
+export interface PendingBannerRequest {
+  id: string;
+  submitterId: string;
+  submitterTag: string;
+  imageUrl: string;
+  guildId: string;
+  channelId: string;
+  messageId: string | null;
+  createdAt: number;
+}
+
+export const TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const pendingRequests = new Map<string, PendingBannerRequest>();
+
+export function createRequest(data: {
+  submitterId: string;
+  submitterTag: string;
+  imageUrl: string;
+  guildId: string;
+  channelId: string;
+}): string {
+  const id = randomUUID();
+  pendingRequests.set(id, {
+    id,
+    ...data,
+    messageId: null,
+    createdAt: Date.now(),
+  });
+  return id;
+}
+
+export function getRequest(id: string): PendingBannerRequest | null {
+  const request = pendingRequests.get(id);
+  if (!request) return null;
+
+  if (Date.now() - request.createdAt > TTL_MS) {
+    pendingRequests.delete(id);
+    return null;
+  }
+
+  return request;
+}
+
+export function setMessageId(id: string, messageId: string): void {
+  const request = pendingRequests.get(id);
+  if (request) {
+    request.messageId = messageId;
+  }
+}
+
+export function removeRequest(id: string): void {
+  pendingRequests.delete(id);
+}
+
+export function cleanupExpired(): void {
+  const now = Date.now();
+  for (const [id, request] of pendingRequests) {
+    if (now - request.createdAt > TTL_MS) {
+      pendingRequests.delete(id);
+    }
+  }
+}
+
+// Auto cleanup every 10 minutes
+setInterval(cleanupExpired, 10 * 60 * 1000).unref();

--- a/src/utils/pendingBans.ts
+++ b/src/utils/pendingBans.ts
@@ -1,0 +1,74 @@
+import { randomUUID } from "node:crypto";
+
+export interface PendingBanRequest {
+  id: string;
+  submitterId: string;
+  submitterTag: string;
+  targetId: string;
+  targetTag: string;
+  reason: string;
+  deleteMessageDays: number;
+  guildId: string;
+  channelId: string;
+  messageId: string | null;
+  createdAt: number;
+}
+
+export const BAN_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+const pendingBans = new Map<string, PendingBanRequest>();
+
+export function createBanRequest(data: {
+  submitterId: string;
+  submitterTag: string;
+  targetId: string;
+  targetTag: string;
+  reason: string;
+  deleteMessageDays: number;
+  guildId: string;
+  channelId: string;
+}): string {
+  const id = randomUUID();
+  pendingBans.set(id, {
+    id,
+    ...data,
+    messageId: null,
+    createdAt: Date.now(),
+  });
+  return id;
+}
+
+export function getBanRequest(id: string): PendingBanRequest | null {
+  const request = pendingBans.get(id);
+  if (!request) return null;
+
+  if (Date.now() - request.createdAt > BAN_TTL_MS) {
+    pendingBans.delete(id);
+    return null;
+  }
+
+  return request;
+}
+
+export function setBanMessageId(id: string, messageId: string): void {
+  const request = pendingBans.get(id);
+  if (request) {
+    request.messageId = messageId;
+  }
+}
+
+export function removeBanRequest(id: string): void {
+  pendingBans.delete(id);
+}
+
+export function cleanupExpiredBans(): void {
+  const now = Date.now();
+  for (const [id, request] of pendingBans) {
+    if (now - request.createdAt > BAN_TTL_MS) {
+      pendingBans.delete(id);
+    }
+  }
+}
+
+// Auto cleanup every 10 minutes
+setInterval(cleanupExpiredBans, 10 * 60 * 1000).unref();

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -1,0 +1,23 @@
+import { type GuildMember, PermissionFlagsBits } from "discord.js";
+
+export const AUTHORIZED_ROLE_IDS: string[] = [
+  "1268946626387378189", // Terminator
+  "1357730279644594399", // Marketer
+  "1324344058138726481", // Developer
+];
+
+export const CONFIRMER_ROLE_ID = "1268946626387378189"; // Terminator
+
+export function hasAuthorizedRole(member: GuildMember): boolean {
+  return member.roles.cache.some((role) =>
+    AUTHORIZED_ROLE_IDS.includes(role.id),
+  );
+}
+
+export function isTerminator(member: GuildMember): boolean {
+  return member.roles.cache.has(CONFIRMER_ROLE_ID);
+}
+
+export function isAdmin(member: GuildMember): boolean {
+  return member.permissions.has(PermissionFlagsBits.Administrator);
+}

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -21,12 +21,3 @@ export function isTerminator(member: GuildMember): boolean {
 export function hasAdministratorPermission(member: GuildMember): boolean {
   return member.permissions.has(PermissionFlagsBits.Administrator);
 }
-
-/**
- * @deprecated Use `hasAdministratorPermission()` when checking the Discord
- * Administrator permission bit. This helper does not represent the bot's
- * role-based admin gate (`config.commandAdminRoleId`).
- */
-export function isAdmin(member: GuildMember): boolean {
-  return hasAdministratorPermission(member);
-}

--- a/src/utils/roles.ts
+++ b/src/utils/roles.ts
@@ -18,6 +18,15 @@ export function isTerminator(member: GuildMember): boolean {
   return member.roles.cache.has(CONFIRMER_ROLE_ID);
 }
 
-export function isAdmin(member: GuildMember): boolean {
+export function hasAdministratorPermission(member: GuildMember): boolean {
   return member.permissions.has(PermissionFlagsBits.Administrator);
+}
+
+/**
+ * @deprecated Use `hasAdministratorPermission()` when checking the Discord
+ * Administrator permission bit. This helper does not represent the bot's
+ * role-based admin gate (`config.commandAdminRoleId`).
+ */
+export function isAdmin(member: GuildMember): boolean {
+  return hasAdministratorPermission(member);
 }


### PR DESCRIPTION
This pull request introduces a new, robust workflow for managing Discord server banner changes, including a two-person approval process, role-based permissions, image validation, request tracking, and audit logging. It also adds infrastructure for handling similar approval flows (such as bans) and improves the bot's modularity and maintainability.

The most important changes are:

**New Banner Change Command & Approval Workflow**
- Added a new `discordbannerset` slash command in `discordbannerset.ts` that allows authorized users to request a server banner change. Non-admins require a second "Terminator" to approve or reject the request via interactive buttons. The process includes permission checks, animated banner requirements, and user feedback.
- Implemented button interaction handling for approval/rejection, with logic to prevent self-approval and to update the request status in real time. [[1]](diffhunk://#diff-ae98883fa992caeaf262adcc60d0004088887ef1f34dda5b2b678d9c4f2d01c5R1-R329) [[2]](diffhunk://#diff-b0dd6aa2ffdba035534c77a5be453f80b646bb6e4cf41576d4994a003641707dR128-R178)

**Image Validation & Pending Request Management**
- Added `imageValidator.ts` to validate banner image attachments and URLs, enforcing file type and size restrictions, and distinguishing animated banners.
- Created `pendingBanners.ts` to track pending banner change requests, manage their lifecycle (creation, retrieval, expiration, message association), and perform periodic cleanup.

**Role & Permission Utilities**
- Introduced `roles.ts` with helpers to check for authorized roles (Terminator, Marketer, Developer), Terminator-only actions, and admin permissions, centralizing role logic.

**Audit Logging**
- Added `logger.ts` to send structured audit logs for banner changes and ban actions to a configurable log channel, including submitter/approver details and image links.

**Infrastructure for Approval Flows**
- Added `pendingBans.ts` to mirror the pending request pattern for ban approvals, supporting future extensibility for similar multi-step moderation actions.
- Updated the main interaction handler to route button interactions to the appropriate command handler based on button IDs, supporting modular multi-command approval flows.

These changes collectively provide a secure, auditable, and user-friendly process for managing sensitive server actions like banner changes, and lay the groundwork for similar workflows elsewhere in the bot.